### PR TITLE
Fix AggregateRoot has aggregate id test

### DIFF
--- a/tests/Service/Prooph/Spec/AggregateAsserter.php
+++ b/tests/Service/Prooph/Spec/AggregateAsserter.php
@@ -33,6 +33,12 @@ final class AggregateAsserter
 
     public function assertAggregateHasProducedEvent($aggregateRoot, AggregateChanged $event): void
     {
+        Assert::eq(
+            (new ClosureAggregateTranslator())->extractAggregateId($aggregateRoot),
+            $event->aggregateId(),
+            'Expected an aggregate id.'
+        );
+
         $producedEvents = $this->closureAggregateTranslator->extractPendingStreamEvents($aggregateRoot);
 
         Assert::true(


### PR DESCRIPTION
Aggregate root has a protected field called aggregateId.
The service ClosureAggregateTranslator is called while the
assertAggregateHasProducedEvent test is running.