### PR TITLE
Fixed some group mistakes

### DIFF
--- a/spec/Domain/Group/Event/GroupNameChangedSpec.php
+++ b/spec/Domain/Group/Event/GroupNameChangedSpec.php
@@ -18,7 +18,7 @@ use App\Domain\Group\Model\GroupName;
 use PhpSpec\ObjectBehavior;
 use Prooph\Common\Messaging\DomainEvent;
 
-final class GroupUpdatedSpec extends ObjectBehavior
+final class GroupNameChangedSpec extends ObjectBehavior
 {
     const UUID = 'e8a68535-3e17-468f-acc3-8a3e0fa04a59';
     const NAME = 'Lorem ipsum';

--- a/spec/Domain/Group/Model/GroupSpec.php
+++ b/spec/Domain/Group/Model/GroupSpec.php
@@ -62,7 +62,7 @@ final class GroupSpec extends ObjectBehavior
 
     public function it_has_a_group_id(): void
     {
-        $this->groupId()->shouldBeLike(new GroupId(self::GROUP_ID));
+        $this->id()->shouldBeLike(new GroupId(self::GROUP_ID));
     }
 
     public function it_has_a_group_name(): void

--- a/spec/Domain/Group/Model/GroupSpec.php
+++ b/spec/Domain/Group/Model/GroupSpec.php
@@ -15,7 +15,7 @@ namespace spec\App\Domain\Group\Model;
 
 use App\Domain\AggregateRoot;
 use App\Domain\Group\Event\GroupAdded;
-use App\Domain\Group\Event\GroupUpdated;
+use App\Domain\Group\Event\GroupNameChanged;
 use App\Domain\Group\Model\GroupId;
 use App\Domain\Group\Model\GroupName;
 use App\Domain\Idea\Event\IdeaAdded;
@@ -95,7 +95,7 @@ final class GroupSpec extends ObjectBehavior
 
         (new AggregateAsserter())->assertAggregateHasProducedEvent(
             $this->getWrappedObject(),
-            GroupUpdated::withData(
+            GroupNameChanged::withData(
                 new GroupId(self::GROUP_ID),
                 new GroupName(self::OTHER_NAME)
             )

--- a/spec/Domain/Group/Model/GroupSpec.php
+++ b/spec/Domain/Group/Model/GroupSpec.php
@@ -67,7 +67,7 @@ final class GroupSpec extends ObjectBehavior
 
     public function it_has_a_group_name(): void
     {
-        $this->groupName()->shouldBeLike(new GroupName(self::NAME));
+        $this->name()->shouldBeLike(new GroupName(self::NAME));
     }
 
     public function it_can_add_ideas(): void
@@ -91,7 +91,7 @@ final class GroupSpec extends ObjectBehavior
 
     public function it_can_update_its_group_name(): void
     {
-        $this->changeGroupName(new GroupName(self::OTHER_NAME));
+        $this->changeName(new GroupName(self::OTHER_NAME));
 
         (new AggregateAsserter())->assertAggregateHasProducedEvent(
             $this->getWrappedObject(),
@@ -101,6 +101,6 @@ final class GroupSpec extends ObjectBehavior
             )
         );
 
-        $this->groupName()->shouldBeLike(new GroupName(self::OTHER_NAME));
+        $this->name()->shouldBeLike(new GroupName(self::OTHER_NAME));
     }
 }

--- a/src/Domain/Group/Event/GroupNameChanged.php
+++ b/src/Domain/Group/Event/GroupNameChanged.php
@@ -17,7 +17,7 @@ use App\Domain\Group\Model\GroupId;
 use App\Domain\Group\Model\GroupName;
 use Prooph\EventSourcing\AggregateChanged;
 
-final class GroupUpdated extends AggregateChanged
+final class GroupNameChanged extends AggregateChanged
 {
     public static function withData(GroupId $groupId, GroupName $groupName): self
     {

--- a/src/Domain/Group/Model/Group.php
+++ b/src/Domain/Group/Model/Group.php
@@ -15,7 +15,7 @@ namespace App\Domain\Group\Model;
 
 use App\Domain\AggregateRoot;
 use App\Domain\Group\Event\GroupAdded;
-use App\Domain\Group\Event\GroupUpdated;
+use App\Domain\Group\Event\GroupNameChanged;
 use App\Domain\Idea\Model\Idea;
 use App\Domain\Idea\Model\IdeaDescription;
 use App\Domain\Idea\Model\IdeaId;
@@ -59,7 +59,7 @@ final class Group extends AggregateRoot
 
     public function changeGroupName(GroupName $groupName): void
     {
-        $this->recordThat(GroupUpdated::withData($this->groupId(), $groupName));
+        $this->recordThat(GroupNameChanged::withData($this->groupId(), $groupName));
     }
 
     public function addIdea(IdeaId $ideaId, IdeaTitle $ideaTitle, IdeaDescription $ideaDescription)
@@ -83,7 +83,7 @@ final class Group extends AggregateRoot
         $this->groupName = $event->groupName();
     }
 
-    protected function applyGroupUpdated(GroupUpdated $event): void
+    protected function applyGroupNameChanged(GroupNameChanged $event): void
     {
         $this->groupName = $event->groupName();
     }

--- a/src/Domain/Group/Model/Group.php
+++ b/src/Domain/Group/Model/Group.php
@@ -44,7 +44,7 @@ final class Group extends AggregateRoot
 
     public function __toString(): string
     {
-        return $this->groupName()->name();
+        return $this->name()->name();
     }
 
     public function groupId(): GroupId
@@ -52,12 +52,12 @@ final class Group extends AggregateRoot
         return $this->groupId;
     }
 
-    public function groupName(): GroupName
+    public function name(): GroupName
     {
         return $this->groupName;
     }
 
-    public function changeGroupName(GroupName $groupName): void
+    public function changeName(GroupName $groupName): void
     {
         $this->recordThat(GroupNameChanged::withData($this->groupId(), $groupName));
     }

--- a/src/Domain/Group/Model/Group.php
+++ b/src/Domain/Group/Model/Group.php
@@ -47,7 +47,7 @@ final class Group extends AggregateRoot
         return $this->name()->name();
     }
 
-    public function groupId(): GroupId
+    public function id(): GroupId
     {
         return $this->groupId;
     }
@@ -59,14 +59,14 @@ final class Group extends AggregateRoot
 
     public function changeName(GroupName $groupName): void
     {
-        $this->recordThat(GroupNameChanged::withData($this->groupId(), $groupName));
+        $this->recordThat(GroupNameChanged::withData($this->id(), $groupName));
     }
 
     public function addIdea(IdeaId $ideaId, IdeaTitle $ideaTitle, IdeaDescription $ideaDescription)
     {
         return Idea::add(
             $ideaId,
-            $this->groupId(),
+            $this->id(),
             $ideaTitle,
             $ideaDescription
         );
@@ -74,7 +74,7 @@ final class Group extends AggregateRoot
 
     protected function aggregateId(): string
     {
-        return $this->groupId()->id();
+        return $this->id()->id();
     }
 
     protected function applyGroupAdded(GroupAdded $event): void


### PR DESCRIPTION
Some mistakes were fixed:

- Method name() instead groupName()
- Event GroupNameChanged instead GroupUpdated.

Closes #44 